### PR TITLE
fix (README): Remove `api-type` flag which does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Then run
 
 ```shell
 pipenv install
-CUDA_VISIBLE_DEVICES=<devices> pipenv run python -m app.main --api-type=code --pretrained=<model> --auth-prefix=<token> --port 8004
+CUDA_VISIBLE_DEVICES=<devices> pipenv run python -m app.main --pretrained=<model> --auth-prefix=<token> --port 8004
 
 ```
 


### PR DESCRIPTION
The example command in README uses a flag `--api-type` which is not present in the list of command-line arguments in `util.py`
https://github.com/dahlker/codeassistant-vscode-endpoint-server/blob/1acd08e94cd2e9882f8527c0b09642bc4df0a327/app/util.py#L6-L17